### PR TITLE
Set compatible Ruby version requirement.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.2.1'
+ruby '~> 2.2'
 
 gem 'bcrypt'
 gem 'rest-client', '~> 1.8'

--- a/rimesync.gemspec
+++ b/rimesync.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.summary     = 'A ruby Gem to interface with the TimeSync API.'
   s.description = 'A ruby Gem to interface with the TimeSync API.'
 
-  s.required_ruby_version     = '>= 1.9.3'
+  s.required_ruby_version     = '>= 2.2.0'
 
   s.add_dependency 'bcrypt', '= 3.1.11'
   s.add_dependency 'rest-client', '= 1.8.0'


### PR DESCRIPTION
Previously, Gemfile required precisely Ruby 2.2.1, but Gemspec allowed at least 1.9.3. After some testing, it would appear Rimesync works on all 2.2 and higher, so the two files have been updated to reflect this.