### PR TITLE
Handle socket errors, which don't have error codes, gracefully.

### DIFF
--- a/lib/rimesync.rb
+++ b/lib/rimesync.rb
@@ -121,9 +121,12 @@ class TimeSync
       response = RestClient.post(url, auth_hash, content_type: :json,
                                                  accept: :json)
       token_response = response_to_ruby(response.body, response.code)
-    rescue => e
+    rescue Net::* => e
       err_msg = format('connection to TimeSync failed at baseurl %s - ', @baseurl)
       err_msg += format('response status was %s', e.http_code)
+      return Hash[@error => err_msg]
+    rescue SocketError => e
+      err_msg = format('connection to TimeSync failed at base url %s - Socket Error', @baseurl)
       return Hash[@error => err_msg]
     end
 

--- a/lib/rimesync.rb
+++ b/lib/rimesync.rb
@@ -121,12 +121,9 @@ class TimeSync
       response = RestClient.post(url, auth_hash, content_type: :json,
                                                  accept: :json)
       token_response = response_to_ruby(response.body, response.code)
-    rescue Net::* => e
+    rescue => e
       err_msg = format('connection to TimeSync failed at baseurl %s - ', @baseurl)
-      err_msg += format('response status was %s', e.http_code)
-      return Hash[@error => err_msg]
-    rescue SocketError => e
-      err_msg = format('connection to TimeSync failed at base url %s - Socket Error', @baseurl)
+      err_msg += format('response status was %s', e.http_code) unless e.is_a? SocketError
       return Hash[@error => err_msg]
     end
 


### PR DESCRIPTION
The rescue statement in the auth function tries to print the HTTP response code when it receives an error, but this doesn't work if the Net code can't even connect to the URL if no server is listening, in which case a SocketError is raised, which doesn't contain an HTTP response code.